### PR TITLE
Updates en traducciones para mensajes de error

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,14 +3,14 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      confirmed: "Tu correo electrónico ha sido confirmado."
+      send_instructions: "Recibirás las instrucciones para confirmar tu correo en unos minutos."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      already_authenticated: "You are already signed in."
+      already_authenticated: "Ya iniciaste sesión."
       inactive: "Your account is not activated yet."
       invalid: "%{authentication_keys} o password inválido."
-      locked: "Your account is locked."
+      locked: "Tu cuenta esta bloqueada."
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "%{authentication_keys} o password inválido."
       timeout: "Your session expired. Please sign in again to continue."
@@ -18,27 +18,27 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Instrucciones de confirmación"
+        subject: "Confima tu correo"
       reset_password_instructions:
-        subject: "Instrucciones de recuperación de cuenta"
+        subject: "Recuperación de cuenta"
       unlock_instructions:
         subject: "Unlock instructions"
       email_changed:
-        subject: "Email Changed"
+        subject: "Cambio de correo electrónico"
       password_change:
-        subject: "Password Changed"
+        subject: "Cambio de contraseña"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "Te hemos enviado un correo con instrucciones de cómo cambiar tu contraseña."
+      send_instructions: "Te enviamos un correo con instrucciones para cambiar tu contraseña."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Tu contraseña se ha actualizado exitosamente. Has iniciado sesión."
+      updated: "Tu contraseña ha sido actualizada exitosamente. Has iniciado sesión."
       updated_not_active: "Tu contraseña fue cambiada correctamente."
     registrations:
       destroyed: "Tu cuenta ha sido cancelada exitosamente. Esperamos verte pronto."
-      signed_up: "Gracias por crear una cuenta en TodoLegal.¡Te damos la bienvenida!"
+      signed_up: "Gracias por crear una cuenta en TodoLegal ¡Te damos la bienvenida!"
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
@@ -55,7 +55,7 @@ en:
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
+      already_confirmed: "Ya ha sido confirmado, intenta iniciar sesión."
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"
       not_found: "not found"


### PR DESCRIPTION
No los traduje todos porque creo que algunas no se usan actualmente. Pero me confirman, si sale mejor traducir todos para evitar casos excepcionales.