### PR TITLE
add entity_encoding as raw

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,7 @@
       selector: '.tinymce',
       plugins: 'lists link table code help wordcount',
       toolbar: 'undo redo | styleselect | bold italic | bullist numlist | alignleft aligncenter alignright alignjustify | outdent indent',
+      entity_encoding: 'raw',
       language: 'es_MX',
       setup: function(editor) {
         editor.on('SkinLoaded', function() {

--- a/app/views/layouts/law.html.erb
+++ b/app/views/layouts/law.html.erb
@@ -45,6 +45,7 @@
       plugins: 'lists link table code help wordcount',
       toolbar: 'undo redo | styleselect | bold italic | bullist numlist | alignleft aligncenter alignright alignjustify | outdent indent',
       language: 'es_MX',
+      entity_encoding: 'raw',
       setup: function(editor) {
         editor.on('SkinLoaded', function() {
           const css = document.createElement("style");


### PR DESCRIPTION
With this configuration, the special characters like á, ñ, and others will not be converted to HTML entities, and you can store the content in the format you desire, such as **COMUNICACIÓN**, in your database.